### PR TITLE
Create a new ClosablePriorityQueue

### DIFF
--- a/gevent_pipeline/__init__.py
+++ b/gevent_pipeline/__init__.py
@@ -1,2 +1,2 @@
-from .closablequeue import ClosableQueue  # noqa
+from .closablequeue import ClosableQueue, ClosablePriorityQueue  # noqa
 from .pipeline import Pipeline, worker, forward_input  # noqa

--- a/gevent_pipeline/closablequeue.py
+++ b/gevent_pipeline/closablequeue.py
@@ -91,7 +91,13 @@ class ClosablePriorityQueue(queue.PriorityQueue, ClosableQueue):
     """
     Mixes gevent's PriorityQueue with the ClosableQueue
 
-    Set as q_out to any pipeline step and join to order the input queue for the
-    next stage
+    This can be useful for ordering output of a pipeline stage.
+
+    Example:
+        >>> cpq = ClosablePriorityQueue()
+        >>> random_array = [random.randint(1,50) for _ in range(10)]
+        >>> output = list(Pipeline().from_iter(random_array, q_out=cpq))
+        >>> sorted(random_array) == output
+        True
     """
     pass

--- a/gevent_pipeline/closablequeue.py
+++ b/gevent_pipeline/closablequeue.py
@@ -94,6 +94,7 @@ class ClosablePriorityQueue(queue.PriorityQueue, ClosableQueue):
     This can be useful for ordering output of a pipeline stage.
 
     Example:
+        >>> from gevent_pipeline import Pipeline
         >>> cpq = ClosablePriorityQueue()
         >>> random_array = [random.randint(1,50) for _ in range(10)]
         >>> output = list(Pipeline().from_iter(random_array, q_out=cpq))

--- a/gevent_pipeline/closablequeue.py
+++ b/gevent_pipeline/closablequeue.py
@@ -86,3 +86,12 @@ class ClosableQueue(queue.Queue):
             return super().get(block=False)
         except Exception:
             return StopIteration
+
+class ClosablePriorityQueue(queue.PriorityQueue, ClosableQueue):
+    """
+    Mixes gevent's PriorityQueue with the ClosableQueue
+
+    Set as q_out to any pipeline step and join to order the input queue for the
+    next stage
+    """
+    pass

--- a/gevent_pipeline/pipeline.py
+++ b/gevent_pipeline/pipeline.py
@@ -295,7 +295,7 @@ class Pipeline:
             raise RuntimeError("Unexpected data on fold output channel")
         return result
 
-    def join(self):
+    def joinall(self):
         """
         Wait for the greenlets to finish
         Wrapper around gevent.joinall
@@ -306,4 +306,4 @@ class Pipeline:
         # TODO pass argumetns to .joinall and remove greenlets in done from _greenlets
         self._greenlets = []
 
-        return done
+        return self

--- a/tests/test_closablequeue.py
+++ b/tests/test_closablequeue.py
@@ -232,7 +232,7 @@ def test_cpq_order_matches():
     randomized = ordered.copy()
     random.shuffle(randomized)
     cpq = ClosablePriorityQueue(fuzz=0.01)
-    for letter in ordered:
+    for letter in randomized:
         cpq.put(letter)
     for orig_el, queued in zip(ordered, cpq):
         assert orig_el == queued

--- a/tests/test_closablequeue.py
+++ b/tests/test_closablequeue.py
@@ -1,4 +1,4 @@
-from gevent_pipeline import ClosableQueue
+from gevent_pipeline import ClosableQueue, ClosablePriorityQueue
 
 import gevent
 from gevent import queue
@@ -224,3 +224,15 @@ def test_cq_maxsize_racy():
     # No items lost
     n_ok_get = n_left_on_queue + n_got
     assert n_ok_get == n_ok_put
+
+def test_cpq_order_matches():
+    # Order of this list matches comparator order for strings.
+    #  Will be randomized and then reordered by the Queue
+    ordered = list('abcdefghijklmnopqrstuvwxyz')
+    randomized = ordered.copy()
+    random.shuffle(randomized)
+    cpq = ClosablePriorityQueue(fuzz=0.01)
+    for letter in ordered:
+        cpq.put(letter)
+    for orig_el, queued in zip(ordered, cpq):
+        assert orig_el == queued


### PR DESCRIPTION
This allows ordering in stages of the pipeline. My idea was to use this with Pipeline.join() to in effect create a bottleneck pipeline stage that forces sequential ordering and then releases to further stages.